### PR TITLE
feat: Adding delimiter parameter to data sent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   #"SecretStorage; sys_platform = 'linux'",
   "click",
   "tqdm",
+  "pyyaml",
 ]
 [project.urls]
 homepage = "https://github.com/kewisch/indico-cli"

--- a/src/indico_cli/indico.py
+++ b/src/indico_cli/indico.py
@@ -187,6 +187,7 @@ class Indico:
         files = {"source_file": ("import.csv", csvout.getvalue())}
         data = {
             "__file_change_trigger": "added-file",
+            "delimiter": "comma",
         }
         if not moderate:
             data["skip_moderation"] = "y"


### PR DESCRIPTION
Adding delimiter parameter to data sent to conform the new changes to Indico API + adding pyyaml to pyproject.toml as it is used.

Indico, at some point, added the following line to their API: https://github.com/indico/indico/blob/e08f19e0617980ff8a978259a0c879fc624fd4c2/indico/modules/events/registration/controllers/management/reglists.py#L506

In the eventual Canonical Indico upgrade, you'll need this to make the script work for bulk registration.